### PR TITLE
Inlined KUBECONFIG in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 test-integration: ## Simple target running a kubectl command to ensure the cluster is up and running
-	kubectl get pods --all-namespaces -o wide
+	kubectl --kubeconfig=$(kind get kubeconfig-path) get nodes && kubectl --kubeconfig=$(kind get kubeconfig-path) get pods --all-namespaces -o wide

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
-test-integration: ## Simple target running a kubectl command to ensure the cluster is up and running
-	kubectl --kubeconfig=$(kind get kubeconfig-path) get nodes && kubectl --kubeconfig=$(kind get kubeconfig-path) get pods --all-namespaces -o wide
+## Simple target running a kubectl command to ensure the cluster is up and running
+## Environment variables are not always recognized by Makefiles, so it's recommended to use the --kubeconfig flag
+test-integration:
+	kubectl --kubeconfig="$(kind get kubeconfig-path)" get nodes && kubectl --kubeconfig="$(kind get kubeconfig-path)" get pods --all-namespaces -o wide

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # travis-kind [![Build Status](https://travis-ci.org/xmudrii/travis-kind.svg?branch=master)](https://travis-ci.org/xmudrii/travis-kind)
 
-This is an example showing how to run Kubernetes 1.11+ on [Travis-CI](https://travis-ci.org/) using [Kubernetes in Docker (`KinD`)](https://sigs.k8s.io/kind). For more details check the lightning talk I held on KubeCon North America 2018: ['Spawning Kubernetes in CI For Integration Tests'](https://sched.co/GrUv).
+This is an example showing how to run Kubernetes 1.11+ on [Travis-CI](https://travis-ci.org/) using [Kubernetes in Docker (`KinD`)](https://sigs.k8s.io/kind). For more details check the lightning talk I held on KubeCon North America 2018: ['Spawning Kubernetes in CI For Integration Tests'](https://sched.co/GrUv)
+and the [follow up article on DZone](https://dzone.com/articles/running-kubernetes-in-the-ci-pipeline-for-integrat).
 
 The recording of the talk is available on [YouTube](https://youtu.be/ZiJn7olAS1M) and the slides are available on [Sched](https://schd.ws/hosted_files/kccna18/28/Spawning%20Kubernetes%20in%20CI%20for%20Integration%20Tests.pdf):
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # travis-kind [![Build Status](https://travis-ci.org/xmudrii/travis-kind.svg?branch=master)](https://travis-ci.org/xmudrii/travis-kind)
 
 This is an example showing how to run Kubernetes 1.11+ on [Travis-CI](https://travis-ci.org/) using [Kubernetes in Docker (`KinD`)](https://sigs.k8s.io/kind). For more details check the lightning talk I held on KubeCon North America 2018: ['Spawning Kubernetes in CI For Integration Tests'](https://sched.co/GrUv)
-and the [follow up article on DZone](https://dzone.com/articles/running-kubernetes-in-the-ci-pipeline-for-integrat).
+and the [follow up article on Loodse blog](https://www.loodse.com/blog/2019-03-12-running-kubernetes-in-the-ci-pipeline-/).
 
 The recording of the talk is available on [YouTube](https://youtu.be/ZiJn7olAS1M) and the slides are available on [Sched](https://schd.ws/hosted_files/kccna18/28/Spawning%20Kubernetes%20in%20CI%20for%20Integration%20Tests.pdf):
 


### PR DESCRIPTION
As noted in your (excellent) https://dzone.com/articles/running-kubernetes-in-the-ci-pipeline-for-integrat article:

> Note: If you’re running kubectl using Makefiles, this approach might not work. Instead, you should inline the environment variable or use the `--kubeconfig` flag.

```bash
KUBECONFIG=$(kind get kubeconfig-path) kubectl get nodes
kubectl --kubeconfig=$(kind get kubeconfig-path) get nodes
```
